### PR TITLE
Adjust/measure base classes: skip reading STDIN if it's a TTY-enabled…

### DIFF
--- a/adjust.py
+++ b/adjust.py
@@ -93,8 +93,11 @@ class Adjust(object):
 
         # Parse input
         try:
-            # self.debug("Reading stdin")
-            input_data = json.loads(sys.stdin.read())
+            stdin_json = {}
+            if not sys.stdin.isatty():
+                # self.debug("Reading stdin")
+                stdin_json = json.loads(sys.stdin.read())
+            input_data = stdin_json
             self.input_data = input_data # LEGACY mode, remove when drivers are updated to use arg
         except Exception as e:
             self.print_json_error(

--- a/measure.py
+++ b/measure.py
@@ -103,8 +103,11 @@ class Measure(object):
 
         # Parse input
         try:
-            self.debug("Reading stdin")
-            self.input_data = json.loads(sys.stdin.read())
+            stdin_json = {}
+            if not sys.stdin.isatty():
+                self.debug("Reading stdin")
+                stdin_json = json.loads(sys.stdin.read())
+            self.input_data = stdin_json
             # TODO: valcheck input
         except Exception as e:
             err = "failed to parse input: " + str(e)


### PR DESCRIPTION
… script run

It's done for the sake of convenience. We would be able to run adjust and measure without a need to provide input and fallback to defaults for that input.