### PR TITLE
Base encoder exception type changed to SettingConfigException

### DIFF
--- a/encoders/base.py
+++ b/encoders/base.py
@@ -111,7 +111,7 @@ class RangeSetting(Setting, ABC):
         if step != 0 and minv != maxv:
             c = (maxv - minv) / float(step)
             if not math.isclose(c, round(c, 0), abs_tol = 1/1024):
-                raise SettingRuntimeException(
+                raise SettingConfigException(
                     'Step value for setting {} must allow to get from {} to {} in equal steps of {}.'.format(
                         q(self.name), minv, maxv, step))
 


### PR DESCRIPTION
Fix for "jvm encoder: unit test fails" - https://app.asana.com/0/1152347948866655/1148806344492473

[JVM unit test](https://github.com/opsani/encoder-jvm/blob/5ba7ddbfbc95b9cfb829aa812904dcaaa30a886e/encoders/test_jvm.py#L331) was expecting a SettingConfigException but encoders/base.py threw SettingRuntimeException