### PR TITLE
Set progress timer daemon=True

### DIFF
--- a/adjust.py
+++ b/adjust.py
@@ -167,7 +167,7 @@ class Adjust(object):
             return
 
         self.timer = Timer(self.progress_interval, self.print_progress)
-        self.timer.daemon = True # allow program to exit when main thread finishes
+        self.timer.daemon = True # allow program to exit when main thread finishes (see https://docs.python.org/3.8/library/threading.html#threading.Thread.daemon)
         self.timer.start()
 
     def print_progress(

--- a/adjust.py
+++ b/adjust.py
@@ -167,6 +167,7 @@ class Adjust(object):
             return
 
         self.timer = Timer(self.progress_interval, self.print_progress)
+        self.timer.daemon = True # allow program to exit when main thread finishes
         self.timer.start()
 
     def print_progress(

--- a/measure.py
+++ b/measure.py
@@ -146,6 +146,7 @@ class Measure(object):
     def start_progress_timer(self):
         self.stop_progress_timer()
         self.timer = Timer(self.progress_interval, self.print_progress)
+        self.timer.daemon = True # allow program to exit when main thread finishes
         self.timer.start()
 
     def print_progress(

--- a/measure.py
+++ b/measure.py
@@ -146,7 +146,7 @@ class Measure(object):
     def start_progress_timer(self):
         self.stop_progress_timer()
         self.timer = Timer(self.progress_interval, self.print_progress)
-        self.timer.daemon = True # allow program to exit when main thread finishes
+        self.timer.daemon = True # allow program to exit when main thread finishes (see https://docs.python.org/3.8/library/threading.html#threading.Thread.daemon)
         self.timer.start()
 
     def print_progress(


### PR DESCRIPTION
Per https://stackoverflow.com/a/11083919

"the thread of the timer can still be alive after the execution of `cancel`" which would cause an unnecessary waiting period as the timer thread will prevent the program from exiting. By setting `daemon=True`, the program will exit once the main thread finishes execution instead of waiting for the timer thread

https://docs.python.org/3.8/library/threading.html#threading.Thread.daemon